### PR TITLE
open the log file as read-only access

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -47,7 +47,7 @@ function getLatestHistory() {
 function addFileDataToHistory(filePath) {
 
     const fileSize = fs.statSync(filePath).size,
-        file = fs.openSync(filePath, 'r+');
+        file = fs.openSync(filePath, 'r');
 
     let bufferSize = 102400,
         readStartingPosition;


### PR DESCRIPTION
Fixes issue #1 created earlier, by lowering the required privileges when opening the log file to read-only.